### PR TITLE
refactored the recoverWith stuff

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 scalaVersion in ThisBuild := "2.11.8"
 
-version in ThisBuild := "1.14.0"
+version in ThisBuild := "1.14.1"
 
 import scalariform.formatter.preferences._
 import com.typesafe.sbt.SbtScalariform

--- a/core/src/main/scala/flow/Generator.scala
+++ b/core/src/main/scala/flow/Generator.scala
@@ -95,10 +95,15 @@ class Generator[+T, +Out](private[flow] val source: () ⇒ Future[Source[T, Futu
   def flatMapMaterializedValue[Out2](f: Out ⇒ Future[Out2])(implicit ec: ExecutionContext) =
     use(() ⇒ source().map(_.mapMaterializedValue(outFuture ⇒ outFuture.flatMap(f))))
 
-  def recoverWith[U >: T, Out2 >: Out](p: PartialFunction[Throwable, Future[Source[U, Future[Out2]]]])(
+  def recoverWithRetries[U >: T, Out2 >: Out](attempts: Int, p: PartialFunction[Throwable, Source[U, akka.NotUsed]])(
+      implicit ec: ExecutionContext): Generator[U, Out2] =
+    use(() ⇒ source().map(_.recoverWithRetries(attempts, p)))
+
+  //allows a recoverWith to be applied to instantiation of the source (which is a Future)
+  def recoverSourceWith[U >: T, Out2 >: Out](p: PartialFunction[Throwable, Future[Source[U, Future[Out2]]]])(
       implicit ec: ExecutionContext): Generator[U, Out2] =
     use(() ⇒ source().recoverWith(p))
-
+    
   def recoverMaterializedValue[Out2 >: Out](p: PartialFunction[Throwable, Out2])(
       implicit ec: ExecutionContext): Generator[T, Out2] =
     use(() ⇒ source().map(_.mapMaterializedValue(outFuture ⇒ outFuture.recover(p))))

--- a/core/src/main/scala/flow/Generator.scala
+++ b/core/src/main/scala/flow/Generator.scala
@@ -199,14 +199,6 @@ class Generator[+T, +Out](private[flow] val source: () ⇒ Future[Source[T, Futu
         })
     }
 
-  def toSource(implicit ec: ExecutionContext): Source[T, Future[Out]] =
-    Source.fromFutureSource(source()).mapMaterializedValue { ff ⇒
-      for {
-        f1 ← ff
-        f2 ← f1
-      } yield f2
-    }
-
   def mapSource[U, Out2](p: Source[T, Future[Out]] ⇒ Source[U, Future[Out2]])(
       implicit ec: ExecutionContext): Generator[U, Out2] =
     use(() ⇒ source().map(p))


### PR DESCRIPTION
The `recoverWith` I had already implemented was really the ability to add a recovery for an error materializing the source.  I made that explicit by calling it `recoverSourceWith`.  I also added a `recoverWithRetries` that is exactly analogous to the akka one.  I think this is much cleaner than I had it before.