### PR TITLE
Remove Generator Options and make future evaluation lazy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ jdk:
   - oraclejdk8
 scala:
   - 2.12.8
+  - 2.11.12
 sudo: false
 # From http://www.scala-sbt.org/1.0/docs/Travis-CI-with-sbt.html#%28Experimental%29+Reusing+Ivy+cache
 # These directories are cached to S3 at the end of the build

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 jdk:
   - oraclejdk8
 scala:
-  - 2.11.8
+  - 2.12.8
 sudo: false
 # From http://www.scala-sbt.org/1.0/docs/Travis-CI-with-sbt.html#%28Experimental%29+Reusing+Ivy+cache
 # These directories are cached to S3 at the end of the build

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ lazy val supportedScalaVersions = List(scala211, scala212)
 
 lazy val commonSettings = Seq(
   organization := "com.datto",
-  scalaVersion := scala212,
+  crossScalaVersions := supportedScalaVersions,
   scalacOptions ++= Seq(
     "-unchecked",
     "-deprecation",
@@ -41,7 +41,6 @@ lazy val core = (project in file("core")).
   settings(
     name := "flow").
   settings(
-    crossScalaVersions := supportedScalaVersions,
     libraryDependencies ++= {
       Seq(
         "com.typesafe.akka"      %% "akka-actor"                           % akkaV,
@@ -55,7 +54,6 @@ lazy val testkit = (project in file("testkit")).
   settings(
     name := "flow-testkit").
   settings(
-    crossScalaVersions := supportedScalaVersions,
     libraryDependencies ++= {
       Seq(
         "org.scalatest"          %% "scalatest"                            % scalaTestV,

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ lazy val scala211 = "2.11.12"
 
 scalaVersion in ThisBuild := scala212
 
-version in ThisBuild := "1.14.2"
+version in ThisBuild := "2.0.0"
 
 lazy val supportedScalaVersions = List(scala211, scala212)
 

--- a/core-tests/src/test/scala/flow/GeneratorTest.scala
+++ b/core-tests/src/test/scala/flow/GeneratorTest.scala
@@ -33,7 +33,7 @@ class GeneratorTest extends TestKit(ActorSystem("GeneratorTest")) with FunSpecLi
     }
 
     it("should be creatable from future source") {
-      val (items, mat) = runGenerator(Generator.future(Future(Source.single(1))))
+      val (items, mat) = runGenerator(Generator.future(() => Future(Source.single(1))))
       assert(items === List(1))
       assert(mat === {})
     }
@@ -70,9 +70,7 @@ class GeneratorTest extends TestKit(ActorSystem("GeneratorTest")) with FunSpecLi
     }
 
     it("should be creatable from a Future") {
-      val gen = Generator.Mat.future {
-        Future { rawSource }
-      }
+      val gen = Generator.Mat.future(() => Future(rawSource))
 
       val (items, mat) = runGenerator(gen)
       assert(items === List(1))
@@ -81,7 +79,7 @@ class GeneratorTest extends TestKit(ActorSystem("GeneratorTest")) with FunSpecLi
 
     it("should lazily evaluate the Future within the generator setup") {
       var x = 0
-      val gen = Generator.Mat.future {
+      val gen = Generator.Mat.future { () =>
         Future {
           x = 1
           rawSource
@@ -133,7 +131,7 @@ class GeneratorTest extends TestKit(ActorSystem("GeneratorTest")) with FunSpecLi
   describe("combining generators") {
     describe("orElse") {
       it("should replace a failing generator with a successful one") {
-        val generator = Generator.Mat.future[Int, Int](Future.failed(new Exception(""))).orElse(rawGenerator)
+        val generator = Generator.Mat.future[Int, Int](() => Future.failed(new Exception(""))).orElse(rawGenerator)
         val (items, mat) = runGenerator(generator)
         assert(items === List(1))
         assert(mat === -1)
@@ -187,7 +185,7 @@ class GeneratorTest extends TestKit(ActorSystem("GeneratorTest")) with FunSpecLi
 
   describe("classifying errors") {
     it("should modify the error of a failed future prior to the generator") {
-      val gen = Generator.future(Future.failed(new Exception)).classifyErrors {
+      val gen = Generator.future(() => Future.failed(new Exception)).classifyErrors {
         case e ⇒ TestError()
       }
       val out = Await.ready(gen.runWith(Sink.seq), 5.seconds).value.get

--- a/core-tests/src/test/scala/flow/GeneratorTest.scala
+++ b/core-tests/src/test/scala/flow/GeneratorTest.scala
@@ -220,8 +220,9 @@ class GeneratorTest extends TestKit(ActorSystem("GeneratorTest")) with FunSpecLi
 
   describe("generator implicits") {
     it("should be able to flatten a future generator") {
-      val futureGen = Future.successful(Generator(Source.single(1)))
-      val res = wait(futureGen.flatten.runWith(Sink.ignore))
+      val futureGen: Future[Generator[Int, Unit]] = Future.successful(Generator(Source.single(1)))
+      val flattened: Generator[Int, Unit] = futureGen.generator
+      val res = wait(flattened.runWith(Sink.ignore))
       assert(res === akka.Done)
     }
 

--- a/core/src/main/scala/flow/GeneratorImplicits.scala
+++ b/core/src/main/scala/flow/GeneratorImplicits.scala
@@ -8,31 +8,31 @@ object GeneratorImplicits {
   private[flow] case class WrappedFutureGenerator[+T, +Out](gen: Future[Generator[T, Out]])(
       implicit ec: ExecutionContext
   ) {
-    def flatten: Generator[T, Out] = Generator.futureGenerator(gen)
+    def generator = Generator.futureGenerator(gen)
   }
 
   private[flow] case class WrappedFutureSourceMat[+T, +Out](source: Future[Source[T, Future[Out]]])(
       implicit ec: ExecutionContext
   ) {
-    def generator: Generator[T, Out] = Generator.Mat.future(source, None)
+    def generator: Generator[T, Out] = Generator.Mat.future(source)
   }
 
   private[flow] case class WrappedFutureSource[+T](source: Future[Source[T, akka.NotUsed]])(
       implicit ec: ExecutionContext
   ) {
-    def generator: Generator[T, Unit] = Generator.future(source, None)
+    def generator: Generator[T, Unit] = Generator.future(source)
   }
 
   private[flow] case class WrappedSourceMat[+T, +Out](source: Source[T, Future[Out]])(implicit ec: ExecutionContext) {
-    def generator: Generator[T, Out] = Generator.Mat(source, None)
+    def generator: Generator[T, Out] = Generator.Mat(source)
   }
 
   private[flow] case class WrappedSource[+T](source: Source[T, akka.NotUsed])(implicit ec: ExecutionContext) {
-    def generator: Generator[T, Unit] = Generator(source, None)
+    def generator: Generator[T, Unit] = Generator(source)
   }
 
   private[flow] case class WrappedStream[+T](stream: Stream[T])(implicit ec: ExecutionContext) {
-    def generator: Generator[T, Unit] = Generator(stream, None)
+    def generator: Generator[T, Unit] = Generator(stream)
   }
 
   implicit def futureGenToWrapped[T, Out](futureGen: Future[Generator[T, Out]])(implicit ec: ExecutionContext) =

--- a/core/src/main/scala/flow/GeneratorImplicits.scala
+++ b/core/src/main/scala/flow/GeneratorImplicits.scala
@@ -8,19 +8,19 @@ object GeneratorImplicits {
   private[flow] case class WrappedFutureGenerator[+T, +Out](gen: Future[Generator[T, Out]])(
       implicit ec: ExecutionContext
   ) {
-    def generator = Generator.futureGenerator(gen)
+    def generator = Generator.futureGenerator(() => gen)
   }
 
   private[flow] case class WrappedFutureSourceMat[+T, +Out](source: Future[Source[T, Future[Out]]])(
       implicit ec: ExecutionContext
   ) {
-    def generator: Generator[T, Out] = Generator.Mat.future(source)
+    def generator: Generator[T, Out] = Generator.Mat.future(() => source)
   }
 
   private[flow] case class WrappedFutureSource[+T](source: Future[Source[T, akka.NotUsed]])(
       implicit ec: ExecutionContext
   ) {
-    def generator: Generator[T, Unit] = Generator.future(source)
+    def generator: Generator[T, Unit] = Generator.future(() => source)
   }
 
   private[flow] case class WrappedSourceMat[+T, +Out](source: Source[T, Future[Out]])(implicit ec: ExecutionContext) {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,3 +5,5 @@ addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.2.1")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.7")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")
+
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.4")

--- a/testkit/src/main/scala/test/GeneratorHelper.scala
+++ b/testkit/src/main/scala/test/GeneratorHelper.scala
@@ -1,7 +1,7 @@
 package datto.flow.test
 
 import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.{Keep, Sink}
+import akka.stream.scaladsl.Sink
 import datto.flow._
 import scala.concurrent._
 import org.scalatest.concurrent.PatienceConfiguration


### PR DESCRIPTION
This contains two changes:

1. Removes `GeneratorOptions`, which don't really belong in this library. Many Generator methods didn't properly support `GeneratorOptions`.
2. Makes `Generator.fromFutureGenerator` lazy, and changed the type signature of all builder methods that take a `Future[_]` to be of type `() => Future[_]`, to better emphasize that the future evaluation should be lazy.

This is a breaking change to the library API.