### PR TITLE
Upgrade to akka 2.6.3

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -3,5 +3,5 @@ style = defaultWithAlign
 maxColumn = 120
 project.git = true
 rewrite.rules = [ RedundantBraces, RedundantParens, SortImports, AvoidInfix, PreferCurlyFors ]
-rewriteTokens = {"=>": "⇒", "<-" : "←", "->" : "→"}
+rewriteTokens = {"⇒": "=>", "←" : "<-", "→" : "->"}
 align.openParenCallSite = false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ jdk:
   - oraclejdk8
 scala:
   - 2.12.10
-  - 2.11.12
 sudo: false
 # From http://www.scala-sbt.org/1.0/docs/Travis-CI-with-sbt.html#%28Experimental%29+Reusing+Ivy+cache
 # These directories are cached to S3 at the end of the build

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ lazy val commonSettings = Seq(
 fork in run := true
 javaOptions in run += "-Xmx8G -XX:+PrintGC"
 
-val akkaV       = "2.6.3"
+val akkaV       = "2.6.4"
 val scalaTestV  = "3.0.8"
 
 lazy val root = project

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,10 @@
 lazy val scala212 = "2.12.10"
-lazy val scala211 = "2.11.12"
 
 scalaVersion in ThisBuild := scala212
 
-version in ThisBuild := "2.0.1"
+version in ThisBuild := "3.0.0"
 
-lazy val supportedScalaVersions = List(scala211, scala212)
+lazy val supportedScalaVersions = List(scala212)
 
 lazy val commonSettings = Seq(
   organization := "com.datto",
@@ -14,14 +13,14 @@ lazy val commonSettings = Seq(
     "-unchecked",
     "-deprecation",
     "-feature",
-    "-Ywarn-unused-import",
-    "-Ywarn-dead-code")) ++ stylePreferences
+    "-Xlint",
+    "-Xfatal-warnings")) ++ stylePreferences
 
 fork in run := true
 javaOptions in run += "-Xmx8G -XX:+PrintGC"
 
-val akkaV       = "2.5.4"
-val scalaTestV  = "3.0.1"
+val akkaV       = "2.6.1"
+val scalaTestV  = "3.0.8"
 
 lazy val root = project
   .in(file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ lazy val commonSettings = Seq(
 fork in run := true
 javaOptions in run += "-Xmx8G -XX:+PrintGC"
 
-val akkaV       = "2.6.1"
+val akkaV       = "2.6.3"
 val scalaTestV  = "3.0.8"
 
 lazy val root = project

--- a/core-tests/src/test/scala/flow/FlowBuilderTest.scala
+++ b/core-tests/src/test/scala/flow/FlowBuilderTest.scala
@@ -5,8 +5,7 @@ import scala.concurrent._
 import scala.util._
 
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.{ Keep, Sink, Source }
+import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.testkit.TestKit
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
@@ -15,61 +14,61 @@ class FlowBuilderTest extends TestKit(ActorSystem("FlowBuilder")) with FunSpecLi
 
   def initialBuilder = FlowBuilder.simple[Int](1)
 
-  implicit val materializer = ActorMaterializer()
   implicit val ec = system.dispatcher
 
-  def runFlow(initialValues: Int*)(flowBuilder: FlowBuilder[Int, Int, Int]): Future[Seq[FlowResult[Int, Int]]] = {
+  def runFlow(initialValues: Int*)(flowBuilder: FlowBuilder[Int, Int, Int]): Future[Seq[FlowResult[Int, Int]]] =
     Source(Stream(initialValues: _*))
-      .map(i ⇒ FlowSuccess(i, i))
+      .map(i => FlowSuccess(i, i))
       .viaMat(flowBuilder.flow)(Keep.right)
       .toMat(Sink.seq)(Keep.right)
       .run
-  }
 
   describe("the flow constructed by a FlowBuilder") {
     describe("synchronous transformations") {
       it("should allow the value to be mapped") {
-        val outFuture = initialBuilder.map(x ⇒ x + 1)
-        whenReady(runFlow(1)(outFuture)) { res ⇒
+        val outFuture = initialBuilder.map(x => x + 1)
+        whenReady(runFlow(1)(outFuture)) { res =>
           assertResult(Success(2))(res.head.value)
         }
       }
 
       it("should allow the value to be flat mapped") {
-        val outFuture = initialBuilder.flatMap(x ⇒ Success(x + 1))
-        whenReady(runFlow(1)(outFuture)) { res ⇒
+        val outFuture = initialBuilder.flatMap(x => Success(x + 1))
+        whenReady(runFlow(1)(outFuture)) { res =>
           assertResult(Success(2))(res.head.value)
         }
       }
 
       it("should allow the result to be mapped with its context") {
-        val outFuture = initialBuilder.mapWithContext((i, ctx, _) ⇒ ctx * 3)
-        whenReady(runFlow(1)(outFuture)) { res ⇒
+        val outFuture = initialBuilder.mapWithContext((i, ctx, _) => ctx * 3)
+        whenReady(runFlow(1)(outFuture)) { res =>
           assertResult(Success(3))(res.head.value)
         }
       }
 
       it("should allow groups of results to be transformed") {
-        val outFuture = initialBuilder.flatMapGrouped(2)(triples ⇒ triples.map(x ⇒ Success(x._1 + 1)))
-        whenReady(runFlow(1, 2)(outFuture)) { res ⇒
+        val outFuture = initialBuilder.flatMapGrouped(2)(triples => triples.map(x => Success(x._1 + 1)))
+        whenReady(runFlow(1, 2)(outFuture)) { res =>
           assertResult(Seq(Success(2), Success(3)))(res.map(_.value))
         }
       }
 
       it("should not callback when grouped if there are no successes") {
-        val outFuture = initialBuilder.flatMap(x ⇒ Failure[Int](new Exception())).flatMapGrouped(1)(group ⇒ {
-          group.map(x ⇒ Success(x._1))
-        })
-        whenReady(runFlow(1)(outFuture)) { res ⇒
+        val outFuture = initialBuilder
+          .flatMap(x => Failure[Int](new Exception()))
+          .flatMapGrouped(1)(group => {
+            group.map(x => Success(x._1))
+          })
+        whenReady(runFlow(1)(outFuture)) { res =>
           assert(res.map(_.value.isSuccess).head === false)
         }
       }
 
       it("should not fail the stream when the callback fails") {
-        val outFuture = initialBuilder.flatMapGrouped(1)(group ⇒ {
+        val outFuture = initialBuilder.flatMapGrouped(1)(group => {
           Seq(Success(Seq[Int]().head))
         })
-        whenReady(runFlow(1)(outFuture)) { res ⇒
+        whenReady(runFlow(1)(outFuture)) { res =>
           assert(res.map(_.value.isSuccess).head === false)
         }
       }
@@ -77,31 +76,32 @@ class FlowBuilderTest extends TestKit(ActorSystem("FlowBuilder")) with FunSpecLi
 
     describe("asynchronous transformations") {
       it("should allow the value to be mapped") {
-        val outFuture = initialBuilder.mapAsync(x ⇒ Future.successful(x + 1))
-        whenReady(runFlow(1)(outFuture)) { res ⇒
+        val outFuture = initialBuilder.mapAsync(x => Future.successful(x + 1))
+        whenReady(runFlow(1)(outFuture)) { res =>
           assertResult(Success(2))(res.head.value)
         }
       }
 
       it("should allow the entire result to be mapped") {
-        val outFuture = initialBuilder.mapWithContextAsync((i, ctx, _) ⇒ Future.successful(ctx * 3))
-        whenReady(runFlow(1)(outFuture)) { res ⇒
+        val outFuture = initialBuilder.mapWithContextAsync((i, ctx, _) => Future.successful(ctx * 3))
+        whenReady(runFlow(1)(outFuture)) { res =>
           assertResult(Success(3))(res.head.value)
         }
       }
 
       it("should allow groups of results to be transformed") {
-        val e = new Exception
-        val outFuture = initialBuilder.flatMapAsyncGrouped(2)(triples ⇒ Future.successful(Seq(Success(1), Failure(e))))
-        whenReady(runFlow(1, 2)(outFuture)) { res ⇒
+        val e         = new Exception
+        val outFuture = initialBuilder.flatMapAsyncGrouped(2)(triples => Future.successful(Seq(Success(1), Failure(e))))
+        whenReady(runFlow(1, 2)(outFuture)) { res =>
           assertResult(Success(1))(res.head.value)
           assertResult(Failure(e))(res(1).value)
         }
       }
 
       it("should apply the transformation to any leftover elements") {
-        val outFuture = initialBuilder.flatMapAsyncGrouped(2)(triples ⇒ Future.successful(triples.map(x ⇒ Success(x._1))))
-        whenReady(runFlow(1, 2, 3)(outFuture)) { res ⇒
+        val outFuture =
+          initialBuilder.flatMapAsyncGrouped(2)(triples => Future.successful(triples.map(x => Success(x._1))))
+        whenReady(runFlow(1, 2, 3)(outFuture)) { res =>
           assertResult(Success(1))(res.head.value)
           assertResult(Success(2))(res(1).value)
           assertResult(Success(3))(res(2).value)
@@ -109,43 +109,44 @@ class FlowBuilderTest extends TestKit(ActorSystem("FlowBuilder")) with FunSpecLi
       }
 
       it("should not callback when grouped if there are no successes") {
-        val outFuture = initialBuilder.flatMap(x ⇒ Failure[Int](new Exception())).flatMapAsyncGrouped(1)(group ⇒ {
-          Future.successful(group.map(x ⇒ Success(x._1)))
-        })
-        whenReady(runFlow(1)(outFuture)) { res ⇒
+        val outFuture = initialBuilder
+          .flatMap(x => Failure[Int](new Exception()))
+          .flatMapAsyncGrouped(1)(group => {
+            Future.successful(group.map(x => Success(x._1)))
+          })
+        whenReady(runFlow(1)(outFuture)) { res =>
           assert(res.map(_.value.isSuccess).head === false)
         }
       }
 
       it("should not fail the stream when the callback fails") {
-        val outFuture = initialBuilder.flatMapAsyncGrouped(1)(group ⇒ {
+        val outFuture = initialBuilder.flatMapAsyncGrouped(1)(group => {
           Future.successful(Seq(Success(Seq[Int]().head)))
         })
-        whenReady(runFlow(1)(outFuture)) { res ⇒
+        whenReady(runFlow(1)(outFuture)) { res =>
           assert(res.map(_.value.isSuccess).head === false)
         }
       }
 
       it("should not fail the stream when the future fails") {
-        val outFuture = initialBuilder.flatMapAsyncGrouped(1)(group ⇒ {
+        val outFuture = initialBuilder.flatMapAsyncGrouped(1)(group => {
           Future.failed[Seq[Try[Int]]](new Exception())
         })
-        whenReady(runFlow(1)(outFuture)) { res ⇒
+        whenReady(runFlow(1)(outFuture)) { res =>
           assert(res.map(_.value.isSuccess).head === false)
         }
       }
 
       it("should support flatMapConcat") {
         val error = new Exception
-        val outFlow = initialBuilder.flatMapConcat { (value, ctx, md) ⇒
+        val outFlow = initialBuilder.flatMapConcat { (value, ctx, md) =>
           val gen: Generator[FlowResult[Int, Int], Unit] =
-            Generator.iterator(() ⇒ Seq(
-              FlowSuccess(value + 1, ctx, md),
-              FlowSuccess(value + 2, ctx, md),
-              FlowFailure(error, ctx, md)).iterator)
+            Generator.iterator(
+              () => Seq(FlowSuccess(value + 1, ctx, md), FlowSuccess(value + 2, ctx, md), FlowFailure(error, ctx, md)).iterator
+            )
           gen
         }
-        whenReady(runFlow(1)(outFlow)) { res ⇒
+        whenReady(runFlow(1)(outFlow)) { res =>
           assert(res.size === 3)
           assertResult(Success(2))(res.head.value)
           assertResult(Success(3))(res(1).value)

--- a/core-tests/src/test/scala/flow/FlowResultTest.scala
+++ b/core-tests/src/test/scala/flow/FlowResultTest.scala
@@ -24,7 +24,7 @@ class FlowResultTest extends FunSpec with ScalaFutures {
 
       it("should not modify failures") {
         val exception = new Exception
-        val res = FlowResult[Int, String](Failure(exception), "")
+        val res       = FlowResult[Int, String](Failure(exception), "")
         assert(res.map(_ + 1).value === Failure(exception))
       }
 
@@ -35,7 +35,7 @@ class FlowResultTest extends FunSpec with ScalaFutures {
 
       it("should preserve metadata") {
         val metadata = Metadata(Seq(MockMetadata))
-        val res = FlowResult(Success(1), "", metadata)
+        val res      = FlowResult(Success(1), "", metadata)
         assert(res.map(_ + 1).metadata === metadata)
       }
     }
@@ -43,50 +43,50 @@ class FlowResultTest extends FunSpec with ScalaFutures {
     describe("flatMap") {
       it("should allow results to be mapped") {
         val res = FlowResult(Success(1), "")
-        assert(res.flatMap(x ⇒ Success(x + 1)).value === Success(2))
+        assert(res.flatMap(x => Success(x + 1)).value === Success(2))
       }
 
       it("should allow a step to fail") {
         val exception = new Exception
-        val res = FlowResult(Success(1), "")
-        val out = res.flatMap(x ⇒ Failure(exception)).value
+        val res       = FlowResult(Success(1), "")
+        val out       = res.flatMap(x => Failure(exception)).value
         assert(out === Failure(exception))
       }
 
       it("should not modify failures") {
         val exception = new Exception
-        val res = FlowResult[Int, String](Failure(exception), "")
-        assert(res.flatMap(x ⇒ Success(x + 1)).value === Failure(exception))
+        val res       = FlowResult[Int, String](Failure(exception), "")
+        assert(res.flatMap(x => Success(x + 1)).value === Failure(exception))
       }
 
       it("should preserve context") {
         val res = FlowResult(Success(1), "ctx")
-        assert(res.flatMap(_ ⇒ Success(1)).context === "ctx")
+        assert(res.flatMap(_ => Success(1)).context === "ctx")
       }
 
       it("should preserve metadata") {
         val metadata = Metadata(Seq(MockMetadata))
-        val res = FlowResult(Success(1), "", metadata)
-        assert(res.flatMap(_ ⇒ Success(1)).metadata === metadata)
+        val res      = FlowResult(Success(1), "", metadata)
+        assert(res.flatMap(_ => Success(1)).metadata === metadata)
       }
     }
 
     describe("mapAsync") {
       it("should allow results to be mapped") {
-        val res = FlowResult(Success(1), "")
-        val outFuture = res.mapAsync(x ⇒ Future.successful(x + 1))
+        val res       = FlowResult(Success(1), "")
+        val outFuture = res.mapAsync(x => Future.successful(x + 1))
 
-        whenReady(outFuture) { out ⇒
+        whenReady(outFuture) { out =>
           assert(out.value === Success(2))
         }
       }
 
       it("should convert failed futures to failed FlowResults, so that the future is always successful") {
-        val res = FlowResult(Success(1), "")
+        val res       = FlowResult(Success(1), "")
         val exception = new Exception
-        val outFuture = res.mapAsync(x ⇒ Future.failed(exception))
+        val outFuture = res.mapAsync(x => Future.failed(exception))
 
-        whenReady(outFuture) { out ⇒
+        whenReady(outFuture) { out =>
           assert(out.value === Failure(exception))
         }
       }
@@ -94,8 +94,8 @@ class FlowResultTest extends FunSpec with ScalaFutures {
 
     describe("addMetadata") {
       it("should allow metadata to be added") {
-        val res = FlowResult(Success(1), "")
-        val entry = MockMetadata
+        val res    = FlowResult(Success(1), "")
+        val entry  = MockMetadata
         val newRes = res.addMetadata(entry)
         assert(newRes.metadata === Metadata(Seq(entry)))
 
@@ -106,22 +106,22 @@ class FlowResultTest extends FunSpec with ScalaFutures {
       it("should recover on a specific error") {
         val res = FlowResult(Failure(MockException()), "")
         val outFuture = res.recoverAsync {
-          case MockException() ⇒ Future.successful(2)
+          case MockException() => Future.successful(2)
         }
 
-        whenReady(outFuture) { out ⇒
+        whenReady(outFuture) { out =>
           assert(out.value === Success(2))
         }
       }
 
       it("should transform errors provided in the recovery block") {
         val res = FlowResult(Failure(MockException()), "")
-        val e = new Exception
+        val e   = new Exception
         val outFuture = res.recoverAsync {
-          case MockException() ⇒ Future.failed(e)
+          case MockException() => Future.failed(e)
         }
 
-        whenReady(outFuture) { out ⇒
+        whenReady(outFuture) { out =>
           assert(out.value === Failure(e))
         }
       }

--- a/core-tests/src/test/scala/flow/GeneratorTest.scala
+++ b/core-tests/src/test/scala/flow/GeneratorTest.scala
@@ -4,8 +4,7 @@ import scala.concurrent._
 import scala.util.Failure
 
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.{ Source, Keep, Sink }
+import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.testkit.TestKit
 import datto.flow.test.GeneratorHelper
 import org.scalatest._
@@ -14,16 +13,19 @@ import scala.concurrent._
 import scala.concurrent.duration._
 import GeneratorImplicits._
 
-class GeneratorTest extends TestKit(ActorSystem("GeneratorTest")) with FunSpecLike with ScalaFutures with GeneratorHelper {
+class GeneratorTest
+    extends TestKit(ActorSystem("GeneratorTest"))
+    with FunSpecLike
+    with ScalaFutures
+    with GeneratorHelper {
 
-  implicit val materializer = ActorMaterializer()
-  implicit val ec = system.dispatcher
+  implicit val ec       = system.dispatcher
   implicit val patience = PatienceConfig(5.seconds, 25.milliseconds)
 
-  val rawSource = Source.single(1).mapMaterializedValue(_ ⇒ Future.successful(-1))
+  val rawSource    = Source.single(1).mapMaterializedValue(_ => Future.successful(-1))
   val rawGenerator = Generator.Mat(rawSource)
 
-  def wait[T](f: ⇒ Future[T]): T = Await.result(f, patience.timeout)
+  def wait[T](f: => Future[T]): T = Await.result(f, patience.timeout)
 
   describe("creating generators without materialized values") {
     it("should be creatable from a NotUsed Source") {
@@ -94,35 +96,35 @@ class GeneratorTest extends TestKit(ActorSystem("GeneratorTest")) with FunSpecLi
 
   describe("modifying generators") {
     it("should support map") {
-      val generator = rawGenerator.map(_ + 1)
+      val generator    = rawGenerator.map(_ + 1)
       val (items, mat) = runGenerator(generator)
       assert(items === List(2))
       assert(mat === -1)
     }
 
     it("should support mapAsync") {
-      val generator = rawGenerator.mapAsync(1)(x ⇒ Future.successful(x + 1))
+      val generator    = rawGenerator.mapAsync(1)(x => Future.successful(x + 1))
       val (items, mat) = runGenerator(generator)
       assert(items === List(2))
       assert(mat === -1)
     }
 
     it("should support mapMaterializedValue") {
-      val generator = rawGenerator.mapMaterializedValue(_ - 1)
+      val generator    = rawGenerator.mapMaterializedValue(_ - 1)
       val (items, mat) = runGenerator(generator)
       assert(items === List(1))
       assert(mat === -2)
     }
 
     it("should support flatMapMaterializedValue") {
-      val generator = rawGenerator.flatMapMaterializedValue(v ⇒ Future.successful(v - 1))
+      val generator    = rawGenerator.flatMapMaterializedValue(v => Future.successful(v - 1))
       val (items, mat) = runGenerator(generator)
       assert(items === List(1))
       assert(mat === -2)
     }
 
     it("should support flatMapConcat") {
-      val generator = rawGenerator.flatMapConcat(4)(i ⇒ Generator.iterator(() ⇒ Seq(i + 1, i + 2).iterator))
+      val generator    = rawGenerator.flatMapConcat(4)(i => Generator.iterator(() => Seq(i + 1, i + 2).iterator))
       val (items, mat) = runGenerator(generator)
       assert(items === List(2, 3))
     }
@@ -131,14 +133,14 @@ class GeneratorTest extends TestKit(ActorSystem("GeneratorTest")) with FunSpecLi
   describe("combining generators") {
     describe("orElse") {
       it("should replace a failing generator with a successful one") {
-        val generator = Generator.Mat.future[Int, Int](() => Future.failed(new Exception(""))).orElse(rawGenerator)
+        val generator    = Generator.Mat.future[Int, Int](() => Future.failed(new Exception(""))).orElse(rawGenerator)
         val (items, mat) = runGenerator(generator)
         assert(items === List(1))
         assert(mat === -1)
       }
 
       it("should not use the provided generator if the first executes successfully") {
-        val generator = rawGenerator.map(_ + 1).orElse(rawGenerator)
+        val generator    = rawGenerator.map(_ + 1).orElse(rawGenerator)
         val (items, mat) = runGenerator(generator)
         assert(items === List(2))
         assert(mat === -1)
@@ -149,14 +151,14 @@ class GeneratorTest extends TestKit(ActorSystem("GeneratorTest")) with FunSpecLi
       val otherSource = rawGenerator.map(_ + 1).mapMaterializedValue(_ - 1)
 
       it("should concat the results of the two generators in the correct order") {
-        val generator = otherSource.concatMat(rawGenerator)(Keep.left)
+        val generator    = otherSource.concatMat(rawGenerator)(Keep.left)
         val (items, mat) = runGenerator(generator)
         assert(items === List(2, 1))
         assert(mat === -2)
       }
 
       it("should materialize the specified value according to the provided combiner") {
-        val generator = otherSource.concatMat(rawGenerator)(Keep.right)
+        val generator    = otherSource.concatMat(rawGenerator)(Keep.right)
         val (items, mat) = runGenerator(generator)
         assert(items === List(2, 1))
         assert(mat === -1)
@@ -176,9 +178,9 @@ class GeneratorTest extends TestKit(ActorSystem("GeneratorTest")) with FunSpecLi
     }
 
     it("should allow for custom materialization combination functions") {
-      val sumBoth = (a: Future[Int], b: Future[Int]) ⇒ a.flatMap(aVal ⇒ b.map(bVal ⇒ aVal + bVal))
+      val sumBoth        = (a: Future[Int], b: Future[Int]) => a.flatMap(aVal => b.map(bVal => aVal + bVal))
       val f: Future[Int] = rawGenerator.runWithMat(Sink.head)(sumBoth)
-      val res = wait(f)
+      val res            = wait(f)
       assert(0 === res)
     }
   }
@@ -186,23 +188,23 @@ class GeneratorTest extends TestKit(ActorSystem("GeneratorTest")) with FunSpecLi
   describe("classifying errors") {
     it("should modify the error of a failed future prior to the generator") {
       val gen = Generator.future(() => Future.failed(new Exception)).classifyErrors {
-        case e ⇒ TestError()
+        case e => TestError()
       }
       val out = Await.ready(gen.runWith(Sink.seq), 5.seconds).value.get
       assert(out == Failure(TestError()))
     }
 
     it("should modify the error of a failed materialized value") {
-      val gen = rawGenerator.flatMapMaterializedValue(_ ⇒ Future.failed(new Exception)).classifyErrors {
-        case e ⇒ TestError()
+      val gen = rawGenerator.flatMapMaterializedValue(_ => Future.failed(new Exception)).classifyErrors {
+        case e => TestError()
       }
       val out = Await.ready(gen.runWithMat(Sink.seq)(Keep.left), 5.seconds).value.get
       assert(out == Failure(TestError()))
     }
 
     it("should modify the error of a generator that fails during the execution of the generator") {
-      val gen = rawGenerator.map(_ ⇒ throw new Exception).classifyErrors {
-        case e ⇒ TestError()
+      val gen = rawGenerator.map(_ => throw new Exception).classifyErrors {
+        case e => TestError()
       }
       val out = Await.ready(gen.runWith(Sink.seq), 5.seconds).value.get
       assert(out == Failure(TestError()))
@@ -219,14 +221,14 @@ class GeneratorTest extends TestKit(ActorSystem("GeneratorTest")) with FunSpecLi
   describe("generator implicits") {
     it("should be able to flatten a future generator") {
       val futureGen: Future[Generator[Int, Unit]] = Future.successful(Generator(Source.single(1)))
-      val flattened: Generator[Int, Unit] = futureGen.generator
-      val res = wait(flattened.runWith(Sink.ignore))
+      val flattened: Generator[Int, Unit]         = futureGen.generator
+      val res                                     = wait(flattened.runWith(Sink.ignore))
       assert(res === akka.Done)
     }
 
     it("should be able to flatten a future source") {
       val futureGen = Future.successful(Source.single(1)).generator
-      val res = wait(futureGen.runWith(Sink.ignore))
+      val res       = wait(futureGen.runWith(Sink.ignore))
       assert(res === akka.Done)
     }
   }

--- a/core-tests/src/test/scala/flow/MergeFlowTest.scala
+++ b/core-tests/src/test/scala/flow/MergeFlowTest.scala
@@ -2,66 +2,57 @@ package datto.flow
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.util.{ Failure, Success, Try }
+import scala.util.{Failure, Success, Try}
 
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.{ Keep, Sink, Source }
+import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.testkit.TestKit
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
 
 class MergeFlowTest extends TestKit(ActorSystem("MergeFlowTest")) with FunSpecLike with ScalaFutures {
 
-  implicit val materializer = ActorMaterializer()
   implicit val ec = system.dispatcher
 
   implicit val patience = PatienceConfig(5.seconds, 10.milliseconds)
 
   case object MockError extends Exception("error")
 
-  val sumFlow = FlowBuilder[Int, String](2).map(x ⇒ x + 1).flow
-  val subtractFlow = FlowBuilder[Int, String](2).map(x ⇒ x - 1).flow
-  val failureFlow = FlowBuilder[Int, String](2).flatMap(x ⇒ Failure(MockError)).flow
+  val sumFlow      = FlowBuilder[Int, String](2).map(x => x + 1).flow
+  val subtractFlow = FlowBuilder[Int, String](2).map(x => x - 1).flow
+  val failureFlow  = FlowBuilder[Int, String](2).flatMap(x => Failure(MockError)).flow
 
-  def runFlow(initialValues: Seq[Try[Int]])(flow: ContextFlow[Int, Int, String]): Future[Seq[FlowResult[Int, String]]] = {
+  def runFlow(initialValues: Seq[Try[Int]])(flow: ContextFlow[Int, Int, String]): Future[Seq[FlowResult[Int, String]]] =
     Source(Stream(initialValues: _*))
-      .map(i ⇒ FlowResult(i, "context"))
+      .map(i => FlowResult(i, "context"))
       .viaMat(flow)(Keep.right)
       .toMat(Sink.seq)(Keep.right)
       .run
-  }
 
   describe("Merging multiple flows") {
     it("should send items down the relevant flows according to the predicate") {
-      val items = Seq(1, -1, 2).map(Success(_))
-      val mergedFlow = MergeFlow[Int, Int, String](
-        (sumFlow, _ > 0),
-        (subtractFlow, _ < 0))
+      val items      = Seq(1, -1, 2).map(Success(_))
+      val mergedFlow = MergeFlow[Int, Int, String]((sumFlow, _ > 0), (subtractFlow, _ < 0))
 
-      whenReady(runFlow(items)(mergedFlow)) { itemResults ⇒
+      whenReady(runFlow(items)(mergedFlow)) { itemResults =>
         assert(Seq(Success(2), Success(-2), Success(3)) == itemResults.map(_.value))
       }
     }
 
     it("should propogate errors created in the child flows to the produced output") {
-      val items = Seq(1, -1, 2).map(Success(_))
-      val mergedFlow = MergeFlow[Int, Int, String](
-        (sumFlow, _ > 0),
-        (failureFlow, _ < 0))
+      val items      = Seq(1, -1, 2).map(Success(_))
+      val mergedFlow = MergeFlow[Int, Int, String]((sumFlow, _ > 0), (failureFlow, _ < 0))
 
-      whenReady(runFlow(items)(mergedFlow)) { itemResults ⇒
+      whenReady(runFlow(items)(mergedFlow)) { itemResults =>
         assert(Seq(Success(2), Failure(MockError), Success(3)) == itemResults.map(_.value))
       }
     }
 
     it("should propogate errors that enter the flow input as output") {
-      val items = Seq(Failure(MockError), Failure(MockError), Success(2))
-      val mergedFlow = MergeFlow[Int, Int, String](
-        (sumFlow, _ > 0),
-        (subtractFlow, _ < 0))
+      val items      = Seq(Failure(MockError), Failure(MockError), Success(2))
+      val mergedFlow = MergeFlow[Int, Int, String]((sumFlow, _ > 0), (subtractFlow, _ < 0))
 
-      whenReady(runFlow(items)(mergedFlow)) { itemResults ⇒
+      whenReady(runFlow(items)(mergedFlow)) { itemResults =>
         assert(Seq(Failure(MockError), Failure(MockError), Success(3)) == itemResults.map(_.value))
       }
     }

--- a/core/src/main/scala/flow/FlowResult.scala
+++ b/core/src/main/scala/flow/FlowResult.scala
@@ -12,7 +12,7 @@ import scala.collection.immutable.{Iterable, Seq}
   */
 object FlowResult {
   def apply[T, Ctx](orig: FlowResult[_, _], value: Try[T], context: Ctx, metadata: Metadata): FlowResult[T, Ctx] =
-    FlowResult(value, context, metadata, orig.timings.add(value.map(v ⇒ v.getClass.toString()).getOrElse("Error")))
+    FlowResult(value, context, metadata, orig.timings.add(value.map(v => v.getClass.toString()).getOrElse("Error")))
 }
 
 case class FlowResult[+T, Ctx](
@@ -22,68 +22,68 @@ case class FlowResult[+T, Ctx](
     timings: TimingList = TimingList()
 ) {
   // try interface
-  def map[U](f: T ⇒ U)                                           = use(value.map(f))
-  def transform[U](s: (T) ⇒ Try[U], f: (Throwable) ⇒ Try[U])     = use(value.transform(s, f))
-  def flatMap[U](f: T ⇒ Try[U])                                  = use(value.flatMap(f))
-  def filter[U](f: T ⇒ Boolean)                                  = use(value.filter(f))
+  def map[U](f: T => U)                                          = use(value.map(f))
+  def transform[U](s: (T) => Try[U], f: (Throwable) => Try[U])   = use(value.transform(s, f))
+  def flatMap[U](f: T => Try[U])                                 = use(value.flatMap(f))
+  def filter[U](f: T => Boolean)                                 = use(value.filter(f))
   def recover[U >: T](f: PartialFunction[Throwable, U])          = use(value.recover(f))
   def recoverWith[U >: T](f: PartialFunction[Throwable, Try[U]]) = use(value.recoverWith(f))
-  def orElse[U >: T](default: ⇒ Try[U])                          = use(value.orElse(default))
+  def orElse[U >: T](default: => Try[U])                         = use(value.orElse(default))
   def flatten[U](implicit ev: <:<[T, Try[U]])                    = use(value.flatten)
-  def getOrElse[U >: T](default: ⇒ U)                            = value.getOrElse(default)
+  def getOrElse[U >: T](default: => U)                           = value.getOrElse(default)
   def toOption                                                   = value.toOption
   def isFailure                                                  = value.isFailure
   def isSuccess                                                  = value.isSuccess
 
-  def mapAsync[U](f: T ⇒ Future[U])(implicit ec: ExecutionContext): Future[FlowResult[U, Ctx]] =
-    mapWithContextAsync((v, _, _) ⇒ f(v))
+  def mapAsync[U](f: T => Future[U])(implicit ec: ExecutionContext): Future[FlowResult[U, Ctx]] =
+    mapWithContextAsync((v, _, _) => f(v))
 
-  def mapWithContext[U](f: (T, Ctx, Metadata) ⇒ U): FlowResult[U, Ctx] = map(v ⇒ f(v, context, metadata))
+  def mapWithContext[U](f: (T, Ctx, Metadata) => U): FlowResult[U, Ctx] = map(v => f(v, context, metadata))
 
-  def mapConcat[U](f: T ⇒ Iterable[U]): Iterable[FlowResult[U, Ctx]] =
-    value.map(v ⇒ f(v)) match {
-      case Success(iter)      ⇒ iter.map(u ⇒ use(Success(u)))
-      case Failure(throwable) ⇒ Seq(FlowResult(Failure[U](throwable), context, metadata, timings))
+  def mapConcat[U](f: T => Iterable[U]): Iterable[FlowResult[U, Ctx]] =
+    value.map(v => f(v)) match {
+      case Success(iter)      => iter.map(u => use(Success(u)))
+      case Failure(throwable) => Seq(FlowResult(Failure[U](throwable), context, metadata, timings))
     }
 
   def mapWithContextAsync[U](
-      f: (T, Ctx, Metadata) ⇒ Future[U]
+      f: (T, Ctx, Metadata) => Future[U]
   )(implicit ec: ExecutionContext): Future[FlowResult[U, Ctx]] =
     value match {
-      case Success(v) ⇒
+      case Success(v) =>
         f(v, context, metadata)
-          .map(newV ⇒ Success(newV))
-          .recover { case e ⇒ Failure[U](e): Try[U] }
-          .map(newV ⇒ FlowResult(this, newV, context, metadata))
-      case Failure(e) ⇒ Future.successful(FlowResult(this, Failure[U](e), context, metadata))
+          .map(newV => Success(newV))
+          .recover { case e => Failure[U](e): Try[U] }
+          .map(newV => FlowResult(this, newV, context, metadata))
+      case Failure(e) => Future.successful(FlowResult(this, Failure[U](e), context, metadata))
     }
 
-  def flatMapWithContext[U](f: (T, Ctx, Metadata) ⇒ Try[U]): FlowResult[U, Ctx] = flatMap(v ⇒ f(v, context, metadata))
+  def flatMapWithContext[U](f: (T, Ctx, Metadata) => Try[U]): FlowResult[U, Ctx] = flatMap(v => f(v, context, metadata))
 
   def mapResultAsync[U](
-      f: FlowResult[T, Ctx] ⇒ Future[FlowResult[U, Ctx]]
+      f: FlowResult[T, Ctx] => Future[FlowResult[U, Ctx]]
   )(implicit ec: ExecutionContext): Future[FlowResult[U, Ctx]] =
-    f(this).recover { case e ⇒ FlowResult(this, Failure[U](e), context, metadata) }
+    f(this).recover { case e => FlowResult(this, Failure[U](e), context, metadata) }
 
   def recoverAsync[U >: T](p: PartialFunction[Throwable, Future[U]])(implicit ec: ExecutionContext) = mapResultAsync {
-    res ⇒
+    res =>
       res.value match {
-        case Failure(e) if p.isDefinedAt(e) ⇒ p(e).map(value ⇒ res.use(Success(value)))
-        case _                              ⇒ Future.successful(res)
+        case Failure(e) if p.isDefinedAt(e) => p(e).map(value => res.use(Success(value)))
+        case _                              => Future.successful(res)
       }
   }
 
-  def addMetadata(entry: MetadataEntry) = ifSuccess(_ ⇒ FlowResult(this, value, context, metadata :+ entry))
+  def addMetadata(entry: MetadataEntry) = ifSuccess(_ => FlowResult(this, value, context, metadata :+ entry))
 
-  def addMetadata(entries: Seq[MetadataEntry]) = ifSuccess(_ ⇒ FlowResult(this, value, context, metadata ++ entries))
+  def addMetadata(entries: Seq[MetadataEntry]) = ifSuccess(_ => FlowResult(this, value, context, metadata ++ entries))
 
-  def addMetadata(f: T ⇒ MetadataEntry) = ifSuccess(v ⇒ FlowResult(this, value, context, metadata :+ f(v)))
+  def addMetadata(f: T => MetadataEntry) = ifSuccess(v => FlowResult(this, value, context, metadata :+ f(v)))
 
-  private def use[U](f: ⇒ Try[U]) = FlowResult(this, f, context, metadata)
+  private def use[U](f: => Try[U]) = FlowResult(this, f, context, metadata)
 
-  private def ifSuccess[U](f: T ⇒ FlowResult[U, Ctx]): FlowResult[U, Ctx] = value match {
-    case Success(v) ⇒ f(v)
-    case Failure(e) ⇒ FlowResult(this, Failure[U](e), context, metadata)
+  private def ifSuccess[U](f: T => FlowResult[U, Ctx]): FlowResult[U, Ctx] = value match {
+    case Success(v) => f(v)
+    case Failure(e) => FlowResult(this, Failure[U](e), context, metadata)
   }
 
   val creationTime = System.currentTimeMillis()
@@ -95,8 +95,8 @@ case object FlowSuccess {
   def apply[T, Ctx](value: T, context: Ctx) = FlowResult[T, Ctx](Success(value), context)
 
   def unapply[T, Ctx](obj: FlowResult[T, Ctx]): Option[(T, Ctx, Metadata)] = obj.value match {
-    case Success(v) ⇒ Some((v, obj.context, obj.metadata))
-    case _          ⇒ None
+    case Success(v) => Some((v, obj.context, obj.metadata))
+    case _          => None
   }
 }
 
@@ -108,14 +108,14 @@ case object FlowFailure {
     FlowResult[T, Ctx](Failure[T](error), context)
 
   def unapply[T, Ctx](obj: FlowResult[T, Ctx]): Option[(Throwable, Ctx, Metadata)] = obj.value match {
-    case Failure(e) ⇒ Some((e, obj.context, obj.metadata))
-    case _          ⇒ None
+    case Failure(e) => Some((e, obj.context, obj.metadata))
+    case _          => None
   }
 
   @SuppressWarnings(Array("org.wartremover.warts.AsInstanceOf"))
   def from[T, U, Ctx](obj: FlowResult[T, Ctx]): FlowResult[U, Ctx] = obj match {
-    case FlowSuccess(v, ctx, md) ⇒ FlowResult(obj, Failure[U](new Exception("Coerced to Failure")), ctx, md)
-    case FlowFailure(e, ctx, md) ⇒ obj.asInstanceOf[FlowResult[U, Ctx]]
+    case FlowSuccess(v, ctx, md) => FlowResult(obj, Failure[U](new Exception("Coerced to Failure")), ctx, md)
+    case FlowFailure(e, ctx, md) => obj.asInstanceOf[FlowResult[U, Ctx]]
   }
 }
 
@@ -126,20 +126,20 @@ object FlowResultFutureImplicits {
   implicit def wrapperToFuture[T, Ctx](wrapper: FutureWrapper[T, Ctx])     = wrapper.future
 
   case class FutureWrapper[T, Ctx](future: Future[FlowResult[T, Ctx]]) {
-    def mapResultValue[U](f: T ⇒ U)(implicit ec: ExecutionContext): Future[FlowResult[U, Ctx]] =
-      flatMapResultValue(v ⇒ Success(f(v)))
+    def mapResultValue[U](f: T => U)(implicit ec: ExecutionContext): Future[FlowResult[U, Ctx]] =
+      flatMapResultValue(v => Success(f(v)))
 
-    def flatMapResultValue[U](f: T ⇒ Try[U])(implicit ec: ExecutionContext): Future[FlowResult[U, Ctx]] =
-      future.map { res ⇒
+    def flatMapResultValue[U](f: T => Try[U])(implicit ec: ExecutionContext): Future[FlowResult[U, Ctx]] =
+      future.map { res =>
         try {
           res.flatMap(f)
-        } catch { case e: Exception ⇒ FlowFailure[U, Ctx](e, res.context) }
+        } catch { case e: Exception => FlowFailure[U, Ctx](e, res.context) }
       }
   }
 }
 
 private[flow] case class TimingStage(description: String, taken: Long) {
-  override def toString() = s"($description: $taken ms)"
+  override def toString() = s"($description: ${taken.toString} ms)"
 }
 
 private[flow] case class TimingList(

--- a/core/src/main/scala/flow/Generator.scala
+++ b/core/src/main/scala/flow/Generator.scala
@@ -1,6 +1,6 @@
 package datto.flow
 
-import akka.stream.{ActorMaterializer, FlowShape, Graph}
+import akka.stream.{FlowShape, Graph, Materializer}
 import akka.stream.scaladsl.{Flow, Keep, RunnableGraph, Sink, Source}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
@@ -8,139 +8,144 @@ import scala.collection.immutable
 
 object Generator {
   object Mat {
-    def future[T, Out](sourceBuilder: () ⇒ Future[Source[T, Future[Out]]]): Generator[T, Out] =
+    def future[T, Out](sourceBuilder: () => Future[Source[T, Future[Out]]]): Generator[T, Out] =
       new Generator(sourceBuilder)
 
-    def apply[T, Out](source: ⇒ Source[T, Future[Out]]): Generator[T, Out] =
+    def apply[T, Out](source: => Source[T, Future[Out]]): Generator[T, Out] =
       Generator.Mat.future(() => Future.successful(source))
   }
 
-  def future[T](sourceBuilder: () ⇒ Future[Source[T, akka.NotUsed]])(implicit ec: ExecutionContext): Generator[T, Unit] =
-    new Generator(() ⇒ sourceBuilder().map(toUnit))
+  def future[T](
+      sourceBuilder: () => Future[Source[T, akka.NotUsed]]
+  )(implicit ec: ExecutionContext): Generator[T, Unit] =
+    new Generator(() => sourceBuilder().map(toUnit))
 
-  def apply[T](source: Source[T, akka.NotUsed])(implicit ec: ExecutionContext): Generator[T, Unit] =
+  def apply[T](source: Source[T, akka.NotUsed]): Generator[T, Unit] =
     Generator.Mat(toUnit(source))
 
-  def apply[T](stream: Stream[T])(implicit ec: ExecutionContext): Generator[T, Unit] =
+  def apply[T](stream: Stream[T]): Generator[T, Unit] =
     Generator.Mat(toUnit(Source(stream)))
 
-  def empty[T](implicit ec: ExecutionContext) = Generator[T](Source.empty[T])
+  def empty[T] = Generator[T](Source.empty[T])
 
-  def single[T](item: T)(implicit ec: ExecutionContext) =
+  def single[T](item: T) =
     Generator[T](Source.single(item))
 
-  def iterator[T](it: () ⇒ Iterator[T])(implicit ec: ExecutionContext) =
+  def iterator[T](it: () => Iterator[T]) =
     Generator(Source.fromIterator(it))
 
   @deprecated("prefer `futureGenerator` which does not eagerly evaluate the future", "datto-flow 2.0.0")
-  def futureGeneratorEager[T, Out](futureGen: ⇒ Future[Generator[T, Out]])(implicit ec: ExecutionContext): Generator[T, Out] = {
+  def futureGeneratorEager[T, Out](
+      futureGen: => Future[Generator[T, Out]]
+  )(implicit ec: ExecutionContext): Generator[T, Out] = {
     val evaluatedFutureGen = futureGen
 
     Generator.Mat.future(() => evaluatedFutureGen.flatMap(_.source()))
   }
 
-  def futureGenerator[T, Out](futureGen: () ⇒ Future[Generator[T, Out]])(implicit ec: ExecutionContext): Generator[T, Out] = {
+  def futureGenerator[T, Out](
+      futureGen: () => Future[Generator[T, Out]]
+  )(implicit ec: ExecutionContext): Generator[T, Out] =
     Generator.Mat.future(() => futureGen().flatMap(_.source()))
-  }
 
   def failed[T, Out](e: Throwable) = Generator.Mat.future[T, Out](() => Future.failed[Source[T, Future[Out]]](e))
 
-  private def toUnit[T](source: Source[T, akka.NotUsed])(implicit ec: ExecutionContext): Source[T, Future[Unit]] =
-    source.mapMaterializedValue(_ ⇒ Future.successful({}))
+  private def toUnit[T](source: Source[T, akka.NotUsed]): Source[T, Future[Unit]] =
+    source.mapMaterializedValue(_ => Future.successful({}))
 }
 
-class Generator[+T, +Out](private[flow] val source: () ⇒ Future[Source[T, Future[Out]]]) {
-  def map[U](f: T ⇒ U)(implicit ec: ExecutionContext): Generator[U, Out] = use(() ⇒ source().map(_.map(f)))
+class Generator[+T, +Out](private[flow] val source: () => Future[Source[T, Future[Out]]]) {
+  def map[U](f: T => U)(implicit ec: ExecutionContext): Generator[U, Out] = use(() => source().map(_.map(f)))
 
-  def mapAsync[U](parallelism: Int)(f: T ⇒ Future[U])(implicit ec: ExecutionContext): Generator[U, Out] =
-    use(() ⇒ source().map(_.mapAsyncUnordered(parallelism)(f)))
+  def mapAsync[U](parallelism: Int)(f: T => Future[U])(implicit ec: ExecutionContext): Generator[U, Out] =
+    use(() => source().map(_.mapAsyncUnordered(parallelism)(f)))
 
-  def mapAsyncOrdered[U](parallelism: Int)(f: T ⇒ Future[U])(implicit ec: ExecutionContext): Generator[U, Out] =
-    use(() ⇒ source().map(_.mapAsync(parallelism)(f)))
+  def mapAsyncOrdered[U](parallelism: Int)(f: T => Future[U])(implicit ec: ExecutionContext): Generator[U, Out] =
+    use(() => source().map(_.mapAsync(parallelism)(f)))
 
-  def mapConcat[U](f: T ⇒ immutable.Iterable[U])(implicit ec: ExecutionContext): Generator[U, Out] =
-    use(() ⇒ source().map(_.mapConcat(f)))
+  def mapConcat[U](f: T => immutable.Iterable[U])(implicit ec: ExecutionContext): Generator[U, Out] =
+    use(() => source().map(_.mapConcat(f)))
 
-  def mapMaterializedValue[Out2](f: Out ⇒ Out2)(implicit ec: ExecutionContext) =
-    flatMapMaterializedValue(out ⇒ Future.successful(f(out)))
+  def mapMaterializedValue[Out2](f: Out => Out2)(implicit ec: ExecutionContext) =
+    flatMapMaterializedValue(out => Future.successful(f(out)))
 
-  def flatMapMaterializedValue[Out2](f: Out ⇒ Future[Out2])(implicit ec: ExecutionContext) =
-    use(() ⇒ source().map(_.mapMaterializedValue(outFuture ⇒ outFuture.flatMap(f))))
+  def flatMapMaterializedValue[Out2](f: Out => Future[Out2])(implicit ec: ExecutionContext) =
+    use(() => source().map(_.mapMaterializedValue(outFuture => outFuture.flatMap(f))))
 
   def recoverWithRetries[U >: T, Out2 >: Out](attempts: Int, p: PartialFunction[Throwable, Source[U, akka.NotUsed]])(
       implicit ec: ExecutionContext
   ): Generator[U, Out2] =
-    use(() ⇒ source().map(_.recoverWithRetries(attempts, p)))
+    use(() => source().map(_.recoverWithRetries(attempts, p)))
 
   //allows a recoverWith to be applied to instantiation of the source (which is a Future)
   def recoverSourceWith[U >: T, Out2 >: Out](
       p: PartialFunction[Throwable, Future[Source[U, Future[Out2]]]]
   )(implicit ec: ExecutionContext): Generator[U, Out2] =
-    use(() ⇒ source().recoverWith(p))
+    use(() => source().recoverWith(p))
 
   def recoverMaterializedValue[Out2 >: Out](
       p: PartialFunction[Throwable, Out2]
   )(implicit ec: ExecutionContext): Generator[T, Out2] =
-    use(() ⇒ source().map(_.mapMaterializedValue(outFuture ⇒ outFuture.recover(p))))
+    use(() => source().map(_.mapMaterializedValue(outFuture => outFuture.recover(p))))
 
   def recoverWithMaterializedValue[Out2 >: Out](
       p: PartialFunction[Throwable, Future[Out2]]
   )(implicit ec: ExecutionContext): Generator[T, Out2] =
-    use(() ⇒ source().map(_.mapMaterializedValue(outFuture ⇒ outFuture.recoverWith[Out2](p))))
+    use(() => source().map(_.mapMaterializedValue(outFuture => outFuture.recoverWith[Out2](p))))
 
   def via[U](flow: Graph[FlowShape[T, U], akka.NotUsed])(implicit ec: ExecutionContext): Generator[U, Out] =
-    use(() ⇒ source().map(_.via(flow)))
+    use(() => source().map(_.via(flow)))
 
   def via[U](flow: Flow[T, U, akka.NotUsed])(implicit ec: ExecutionContext): Generator[U, Out] =
-    use(() ⇒ source().map(_.via(flow)))
+    use(() => source().map(_.via(flow)))
 
   def viaMat[U, Mat2, Mat3](
       flow: Graph[FlowShape[T, U], Mat2]
-  )(combine: (Future[Out], Mat2) ⇒ Future[Mat3])(implicit ec: ExecutionContext): Generator[U, Mat3] =
-    use(() ⇒ source().map(_.viaMat(flow)(combine)))
+  )(combine: (Future[Out], Mat2) => Future[Mat3])(implicit ec: ExecutionContext): Generator[U, Mat3] =
+    use(() => source().map(_.viaMat(flow)(combine)))
 
   def viaMat[U, Mat2, Mat3](
       flow: Flow[T, U, Mat2]
-  )(combine: (Future[Out], Mat2) ⇒ Future[Mat3])(implicit ec: ExecutionContext): Generator[U, Mat3] =
-    use(() ⇒ source().map(_.viaMat(flow)(combine)))
+  )(combine: (Future[Out], Mat2) => Future[Mat3])(implicit ec: ExecutionContext): Generator[U, Mat3] =
+    use(() => source().map(_.viaMat(flow)(combine)))
 
   def toMat[Out2, Out3](
       sink: Sink[T, Out2]
-  )(combine: (Future[Out], Out2) ⇒ Out3)(implicit ec: ExecutionContext): Future[RunnableGraph[Out3]] =
+  )(combine: (Future[Out], Out2) => Out3)(implicit ec: ExecutionContext): Future[RunnableGraph[Out3]] =
     source().map(_.toMat(sink)(combine))
 
   def to[Out2](sink: Sink[T, Out2])(implicit ec: ExecutionContext) = toMat(sink)(Keep.left)
 
   def runWithMat[Out2, Out3](sink: Sink[T, Future[Out2]])(
-      combine: (Future[Out], Future[Out2]) ⇒ Future[Out3]
-  )(implicit ec: ExecutionContext, mat: ActorMaterializer): Future[Out3] =
+      combine: (Future[Out], Future[Out2]) => Future[Out3]
+  )(implicit ec: ExecutionContext, mat: Materializer): Future[Out3] =
     toMat(sink)(combine)
       .flatMap(_.run())
 
-  def runWith[Out2](sink: Sink[T, Future[Out2]])(implicit ec: ExecutionContext, mat: ActorMaterializer): Future[Out2] =
+  def runWith[Out2](sink: Sink[T, Future[Out2]])(implicit ec: ExecutionContext, mat: Materializer): Future[Out2] =
     runWithMat(sink)(Keep.right)
 
   def orElse[U >: T, Out2 >: Out](other: Generator[U, Out2])(implicit ec: ExecutionContext): Generator[U, Out2] =
-    use(() ⇒ source().recoverWith { case _ ⇒ other.source() })
+    use(() => source().recoverWith { case _ => other.source() })
 
   def concatMat[U >: T, Out2, Out3](
       other: Generator[U, Out2]
-  )(combine: (Future[Out], Future[Out2]) ⇒ Future[Out3])(implicit ec: ExecutionContext): Generator[U, Out3] =
+  )(combine: (Future[Out], Future[Out2]) => Future[Out3])(implicit ec: ExecutionContext): Generator[U, Out3] =
     use(
-      () ⇒
+      () =>
         for {
-          source1 ← source()
-          source2 ← other.source()
+          source1 <- source()
+          source2 <- other.source()
         } yield source1.concatMat(source2)(combine)
     )
 
-  def filter(predicate: T ⇒ Boolean)(implicit ec: ExecutionContext) = use(() ⇒ source().map(_.filter(predicate)))
+  def filter(predicate: T => Boolean)(implicit ec: ExecutionContext) = use(() => source().map(_.filter(predicate)))
 
   def concat[U >: T](other: Generator[U, _])(implicit ec: ExecutionContext): Generator[U, Out] =
     concatMat(other)(Keep.left)
 
   def grouped(size: Int)(implicit ec: ExecutionContext): Generator[Seq[T], Out] =
-    use(() ⇒ source().map(_.grouped(size)))
+    use(() => source().map(_.grouped(size)))
 
   def throttle(elements: Int, per: FiniteDuration = 1.second)(implicit ec: ExecutionContext): Generator[T, Out] =
     throttle(elements, per, elements)
@@ -148,9 +153,9 @@ class Generator[+T, +Out](private[flow] val source: () ⇒ Future[Source[T, Futu
   def throttle(elements: Int, per: FiniteDuration, maximumBurst: Int)(
       implicit ec: ExecutionContext
   ): Generator[T, Out] =
-    use(() ⇒ source().map(_.throttle(elements, per, maximumBurst, akka.stream.ThrottleMode.Shaping)))
+    use(() => source().map(_.throttle(elements, per, maximumBurst, akka.stream.ThrottleMode.Shaping)))
 
-  def throttle(elements: Int, per: FiniteDuration, maximumBurst: Int, costCalculation: (T) ⇒ Int)(
+  def throttle(elements: Int, per: FiniteDuration, maximumBurst: Int, costCalculation: (T) => Int)(
       implicit ec: ExecutionContext
   ): Generator[T, Out] =
     throttle(elements, per, maximumBurst, costCalculation, akka.stream.ThrottleMode.Shaping)
@@ -159,34 +164,34 @@ class Generator[+T, +Out](private[flow] val source: () ⇒ Future[Source[T, Futu
       elements: Int,
       per: FiniteDuration,
       maximumBurst: Int,
-      costCalculation: (T) ⇒ Int,
+      costCalculation: (T) => Int,
       mode: akka.stream.ThrottleMode
   )(implicit ec: ExecutionContext): Generator[T, Out] =
-    use(() ⇒ source().map(_.throttle(elements, per, maximumBurst, costCalculation, mode)))
+    use(() => source().map(_.throttle(elements, per, maximumBurst, costCalculation, mode)))
 
-  def flatMapConcat[U](parallelism: Int)(f: T ⇒ Generator[U, Unit])(implicit ec: ExecutionContext) =
-    use(() ⇒ mapAsync(parallelism)(x ⇒ f(x).source()).source().map(_.flatMapConcat(x ⇒ x)))
+  def flatMapConcat[U](parallelism: Int)(f: T => Generator[U, Unit])(implicit ec: ExecutionContext) =
+    use(() => mapAsync(parallelism)(x => f(x).source()).source().map(_.flatMapConcat(x => x)))
 
   def classifyErrors[Out2 >: Out](classifier: PartialFunction[Throwable, Throwable])(implicit ec: ExecutionContext) =
-    use { () ⇒
+    use { () =>
       source()
-        .recoverWith(classifier.andThen(Future.failed))
+        .recoverWith(classifier.andThen(Future.failed(_)))
         .map(
-          s ⇒
+          s =>
             s.recoverWithRetries(1, {
-              case e if classifier.isDefinedAt(e) ⇒ Source.failed(classifier(e))
+              case e if classifier.isDefinedAt(e) => Source.failed(classifier(e))
             })
         )
-        .map(_.mapMaterializedValue { future ⇒
-          future.recoverWith(classifier.andThen(Future.failed))
+        .map(_.mapMaterializedValue { future =>
+          future.recoverWith(classifier.andThen(Future.failed(_)))
         })
     }
 
   def mapSource[U, Out2](
-      p: Source[T, Future[Out]] ⇒ Source[U, Future[Out2]]
+      p: Source[T, Future[Out]] => Source[U, Future[Out2]]
   )(implicit ec: ExecutionContext): Generator[U, Out2] =
-    use(() ⇒ source().map(p))
+    use(() => source().map(p))
 
-  private def use[U, Out2](source: () ⇒ Future[Source[U, Future[Out2]]]) = new Generator(source)
+  private def use[U, Out2](source: () => Future[Source[U, Future[Out2]]]) = new Generator(source)
 
 }

--- a/core/src/main/scala/flow/GeneratorImplicits.scala
+++ b/core/src/main/scala/flow/GeneratorImplicits.scala
@@ -11,9 +11,7 @@ object GeneratorImplicits {
     def generator = Generator.futureGenerator(() => gen)
   }
 
-  private[flow] case class WrappedFutureSourceMat[+T, +Out](source: Future[Source[T, Future[Out]]])(
-      implicit ec: ExecutionContext
-  ) {
+  private[flow] case class WrappedFutureSourceMat[+T, +Out](source: Future[Source[T, Future[Out]]]) {
     def generator: Generator[T, Out] = Generator.Mat.future(() => source)
   }
 
@@ -23,33 +21,33 @@ object GeneratorImplicits {
     def generator: Generator[T, Unit] = Generator.future(() => source)
   }
 
-  private[flow] case class WrappedSourceMat[+T, +Out](source: Source[T, Future[Out]])(implicit ec: ExecutionContext) {
+  private[flow] case class WrappedSourceMat[+T, +Out](source: Source[T, Future[Out]]) {
     def generator: Generator[T, Out] = Generator.Mat(source)
   }
 
-  private[flow] case class WrappedSource[+T](source: Source[T, akka.NotUsed])(implicit ec: ExecutionContext) {
+  private[flow] case class WrappedSource[+T](source: Source[T, akka.NotUsed]) {
     def generator: Generator[T, Unit] = Generator(source)
   }
 
-  private[flow] case class WrappedStream[+T](stream: Stream[T])(implicit ec: ExecutionContext) {
+  private[flow] case class WrappedStream[+T](stream: Stream[T]) {
     def generator: Generator[T, Unit] = Generator(stream)
   }
 
   implicit def futureGenToWrapped[T, Out](futureGen: Future[Generator[T, Out]])(implicit ec: ExecutionContext) =
     WrappedFutureGenerator(futureGen)
 
-  implicit def futureSourceMatToWrapped[T, Out](source: Future[Source[T, Future[Out]]])(implicit ec: ExecutionContext) =
+  implicit def futureSourceMatToWrapped[T, Out](source: Future[Source[T, Future[Out]]]) =
     WrappedFutureSourceMat(source)
 
   implicit def futureSourceToWrapped[T](source: Future[Source[T, akka.NotUsed]])(implicit ec: ExecutionContext) =
     WrappedFutureSource(source)
 
-  implicit def sourceMatToWrapped[T, Out](source: Source[T, Future[Out]])(implicit ec: ExecutionContext) =
+  implicit def sourceMatToWrapped[T, Out](source: Source[T, Future[Out]]) =
     WrappedSourceMat(source)
 
-  implicit def sourceToWrapped[T](source: Source[T, akka.NotUsed])(implicit ec: ExecutionContext) =
+  implicit def sourceToWrapped[T](source: Source[T, akka.NotUsed]) =
     WrappedSource(source)
 
-  implicit def sourceToWrapped[T](stream: Stream[T])(implicit ec: ExecutionContext) =
+  implicit def sourceToWrapped[T](stream: Stream[T]) =
     WrappedStream(stream)
 }

--- a/core/src/main/scala/flow/MergeFlow.scala
+++ b/core/src/main/scala/flow/MergeFlow.scala
@@ -68,14 +68,14 @@ import akka.stream._
 object MergeFlow {
 
   def withContext[A, B, Ctx](
-      flowPredicatePairs: (ContextFlow[A, B, Ctx], (A, Ctx, Metadata) ⇒ Boolean)*
+      flowPredicatePairs: (ContextFlow[A, B, Ctx], (A, Ctx, Metadata) => Boolean)*
   ): ContextFlow[A, B, Ctx] = {
     val errorPropogatingFlow: ContextFlow[A, B, Ctx] =
       FlowBuilder[A, Ctx](1).filter(_.isFailure).flow.map(_.asInstanceOf[FlowResult[B, Ctx]])
 
-    val filteredFlows = flowPredicatePairs.map { pair ⇒
+    val filteredFlows = flowPredicatePairs.map { pair =>
       FlowBuilder[A, Ctx](1)
-        .filter(r ⇒ r.value.toOption.map(value ⇒ pair._2(value, r.context, r.metadata)).getOrElse(false))
+        .filter(r => r.value.toOption.map(value => pair._2(value, r.context, r.metadata)).getOrElse(false))
         .flow
         .via(pair._1)
     }
@@ -85,18 +85,18 @@ object MergeFlow {
     merge(allFlows: _*)
   }
 
-  def apply[A, B, Ctx](flowPredicatePairs: (ContextFlow[A, B, Ctx], A ⇒ Boolean)*): ContextFlow[A, B, Ctx] =
+  def apply[A, B, Ctx](flowPredicatePairs: (ContextFlow[A, B, Ctx], A => Boolean)*): ContextFlow[A, B, Ctx] =
     withContext(flowPredicatePairs.map {
-      case (flow, predicate) ⇒ (flow, (value: A, context: Ctx, md: Metadata) ⇒ predicate(value))
+      case (flow, predicate) => (flow, (value: A, context: Ctx, md: Metadata) => predicate(value))
     }: _*)
 
   def merge[A, B, Ctx](flows: ContextFlow[A, B, Ctx]*): ContextFlow[A, B, Ctx] =
-    Flow.fromGraph(GraphDSL.create() { implicit b ⇒
+    Flow.fromGraph(GraphDSL.create() { implicit b =>
       import GraphDSL.Implicits._
       val broadcast = b.add(Broadcast[FlowResult[A, Ctx]](flows.length))
       val merge     = b.add(Merge[FlowResult[B, Ctx]](flows.length))
 
-      flows.zipWithIndex.foreach(pair ⇒ broadcast.out(pair._2) ~> pair._1 ~> merge.in(pair._2))
+      flows.zipWithIndex.foreach(pair => broadcast.out(pair._2) ~> pair._1 ~> merge.in(pair._2))
       FlowShape(broadcast.in, merge.out)
     })
 }

--- a/core/src/main/scala/flow/Metadata.scala
+++ b/core/src/main/scala/flow/Metadata.scala
@@ -10,8 +10,8 @@ case class Metadata(entries: Seq[MetadataEntry]) extends Seq[MetadataEntry] {
   def length            = entries.length
 
   def ofType[T <: MetadataEntry](implicit ev: ClassTag[T]): Seq[T] = entries.flatMap {
-    case entry: T ⇒ Some(entry)
-    case _        ⇒ None: Option[T]
+    case entry: T => Some(entry)
+    case _        => None: Option[T]
   }
 
   def findOfType[T <: MetadataEntry](implicit ev: ClassTag[T]): Option[T] = ofType[T].headOption

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.5
+sbt.version=1.3.8

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+sbt.version=1.3.5

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.0")
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.2.1")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.3")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.7")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")

--- a/testkit/src/main/scala/test/GeneratorHelper.scala
+++ b/testkit/src/main/scala/test/GeneratorHelper.scala
@@ -1,6 +1,6 @@
 package datto.flow.test
 
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import akka.stream.scaladsl.Sink
 import datto.flow._
 import scala.concurrent._
@@ -9,10 +9,10 @@ import org.scalatest.concurrent.PatienceConfiguration
 trait GeneratorHelper extends PatienceConfiguration {
   def runGenerator[T, Out](
       gen: Generator[T, Out]
-  )(implicit mat: ActorMaterializer, patience: PatienceConfig, ec: ExecutionContext) = {
+  )(implicit mat: Materializer, patience: PatienceConfig, ec: ExecutionContext) = {
     val eventuallyItemsAndMat = gen.runWithMat(Sink.seq) {
-      case (eventuallyMat, eventuallyItems) ⇒
-        eventuallyMat.flatMap(mat ⇒ eventuallyItems.map(items ⇒ (items.toList, mat)))
+      case (eventuallyMat, eventuallyItems) =>
+        eventuallyMat.flatMap(mat => eventuallyItems.map(items => (items.toList, mat)))
     }
     Await.result(eventuallyItemsAndMat, patience.timeout)
   }


### PR DESCRIPTION
- Removes support for scala 2.11.x
- upgrade to scalafmt 1.3.8
- Removes any `materializer = ActorMaterializer()` as `ActorMaterializer` is now deprecated in favor of `Materializer` and an `implicit materializer` is provided if there is an `implicit ActorSystem` available
- Removes unicode arrows
