### PR TITLE
Upgrade to Scala 2.13.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val scala213 = "2.13.8"
 
 ThisBuild / scalaVersion := scala213
 
-ThisBuild / version := "3.1.1-SNAPSHOT"
+ThisBuild / version := "3.2.0"
 
 lazy val supportedScalaVersions = List(scala213)
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,10 @@
-lazy val scala212 = "2.12.15"
+lazy val scala213 = "2.13.8"
 
-ThisBuild / scalaVersion := scala212
+ThisBuild / scalaVersion := scala213
 
-ThisBuild / version := "3.1.0"
+ThisBuild / version := "3.1.1-SNAPSHOT"
 
-lazy val supportedScalaVersions = List(scala212)
+lazy val supportedScalaVersions = List(scala213)
 
 lazy val commonSettings = Seq(
   organization := "com.datto",

--- a/core-tests/src/test/scala/flow/FlowBuilderTest.scala
+++ b/core-tests/src/test/scala/flow/FlowBuilderTest.scala
@@ -1,6 +1,5 @@
 package datto.flow
 
-import scala.collection.immutable.Seq
 import scala.concurrent._
 import scala.util._
 
@@ -17,11 +16,11 @@ class FlowBuilderTest extends TestKit(ActorSystem("FlowBuilder")) with FunSpecLi
   implicit val ec = system.dispatcher
 
   def runFlow(initialValues: Int*)(flowBuilder: FlowBuilder[Int, Int, Int]): Future[Seq[FlowResult[Int, Int]]] =
-    Source(Stream(initialValues: _*))
+    Source(LazyList(initialValues: _*))
       .map(i => FlowSuccess(i, i))
       .viaMat(flowBuilder.flow)(Keep.right)
       .toMat(Sink.seq)(Keep.right)
-      .run
+      .run()
 
   describe("the flow constructed by a FlowBuilder") {
     describe("synchronous transformations") {

--- a/core-tests/src/test/scala/flow/GeneratorTest.scala
+++ b/core-tests/src/test/scala/flow/GeneratorTest.scala
@@ -9,7 +9,6 @@ import akka.testkit.TestKit
 import datto.flow.test.GeneratorHelper
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
-import scala.concurrent._
 import scala.concurrent.duration._
 import GeneratorImplicits._
 

--- a/core-tests/src/test/scala/flow/MergeFlowTest.scala
+++ b/core-tests/src/test/scala/flow/MergeFlowTest.scala
@@ -23,11 +23,11 @@ class MergeFlowTest extends TestKit(ActorSystem("MergeFlowTest")) with FunSpecLi
   val failureFlow  = FlowBuilder[Int, String](2).flatMap(x => Failure(MockError)).flow
 
   def runFlow(initialValues: Seq[Try[Int]])(flow: ContextFlow[Int, Int, String]): Future[Seq[FlowResult[Int, String]]] =
-    Source(Stream(initialValues: _*))
+    Source(LazyList(initialValues: _*))
       .map(i => FlowResult(i, "context"))
       .viaMat(flow)(Keep.right)
       .toMat(Sink.seq)(Keep.right)
-      .run
+      .run()
 
   describe("Merging multiple flows") {
     it("should send items down the relevant flows according to the predicate") {

--- a/core/src/main/scala/flow/FlowBuilder.scala
+++ b/core/src/main/scala/flow/FlowBuilder.scala
@@ -26,7 +26,7 @@ import collection.immutable.{Iterable, Seq}
   *   .flatMap {
   *     case i if i < 0 => Failure(new Exception("number is negative!"))
   *     case i => Success(i)
-  *   }.mapWithContext((i, context, metadata) => s"Value: $i, Context: $context")
+  *   }.mapWithContext((i, context, metadata) => s"Value: $$i, Context: $$context")
   *   .flow
   *
   * This starts with an initial Flow containing FlowResults of integers (and with context as the initia int value).
@@ -159,6 +159,7 @@ case class FlowBuilder[I, T, Ctx](
           case _ =>
             Try(f(successes.map(ir => (ir.value.get, ir.context, ir.metadata))).zip(successes).map {
               case (tryResult, FlowSuccess(_, context, metadata)) => FlowResult[U, Ctx](tryResult, context, metadata)
+              case _                                              => throw new Exception("Unexpected non-success FlowResult")
             }) match {
               case Success(result) => result
               case Failure(e) =>
@@ -189,6 +190,7 @@ case class FlowBuilder[I, T, Ctx](
                 results.zip(originals).map {
                   case (tryResult, FlowSuccess(_, context, metadata)) =>
                     FlowResult[U, Ctx](tryResult, context, metadata)
+                  case _ => throw new Exception("Unexpected non-success FlowResult")
                 }
             }) match {
               case Success(result) =>

--- a/core/src/main/scala/flow/FlowBuilder.scala
+++ b/core/src/main/scala/flow/FlowBuilder.scala
@@ -158,7 +158,7 @@ case class FlowBuilder[I, T, Ctx](
           case 0 => Seq[FlowResult[U, Ctx]]()
           case _ =>
             Try(f(successes.map(ir => (ir.value.get, ir.context, ir.metadata))).zip(successes).map {
-              case (tryResult, FlowResult(_, context, metadata, _)) => FlowResult[U, Ctx](tryResult, context, metadata)
+              case (tryResult, FlowSuccess(_, context, metadata)) => FlowResult[U, Ctx](tryResult, context, metadata)
             }) match {
               case Success(result) => result
               case Failure(e) =>
@@ -187,7 +187,7 @@ case class FlowBuilder[I, T, Ctx](
             Try(f(successes.map(ir => (ir.value.get, ir.context, ir.metadata))).zip(Future.successful(successes)).map {
               case (results, originals) =>
                 results.zip(originals).map {
-                  case (tryResult, FlowResult(_, context, metadata, _)) =>
+                  case (tryResult, FlowSuccess(_, context, metadata)) =>
                     FlowResult[U, Ctx](tryResult, context, metadata)
                 }
             }) match {

--- a/core/src/main/scala/flow/FlowBuilder.scala
+++ b/core/src/main/scala/flow/FlowBuilder.scala
@@ -9,7 +9,7 @@ import scala.util.{Failure, Success, Try}
 import collection.immutable.{Iterable, Seq}
 
 /**
-  * A FlowBuilder provides tools for cunstructing an akka.stream Flow that transforms a
+  * A FlowBuilder provides tools for constructing an akka.stream Flow that transforms a
   * FlowResult into another FlowResult. More explicitly, it is used to construct a
   * Flow[FlowResult[I, Ctx], FlowResult[T, Ctx], akka.NotUsed]. Here I is thought of as the
   * initial or input type, T is the terminal or output type, and Ctx is the context type which
@@ -158,7 +158,7 @@ case class FlowBuilder[I, T, Ctx](
           case 0 => Seq[FlowResult[U, Ctx]]()
           case _ =>
             Try(f(successes.map(ir => (ir.value.get, ir.context, ir.metadata))).zip(successes).map {
-              case (tryResult, FlowSuccess(_, context, metadata)) => FlowResult[U, Ctx](tryResult, context, metadata)
+              case (tryResult, FlowResult(_, context, metadata, _)) => FlowResult[U, Ctx](tryResult, context, metadata)
             }) match {
               case Success(result) => result
               case Failure(e) =>
@@ -187,7 +187,7 @@ case class FlowBuilder[I, T, Ctx](
             Try(f(successes.map(ir => (ir.value.get, ir.context, ir.metadata))).zip(Future.successful(successes)).map {
               case (results, originals) =>
                 results.zip(originals).map {
-                  case (tryResult, FlowSuccess(_, context, metadata)) =>
+                  case (tryResult, FlowResult(_, context, metadata, _)) =>
                     FlowResult[U, Ctx](tryResult, context, metadata)
                 }
             }) match {

--- a/core/src/main/scala/flow/FlowResult.scala
+++ b/core/src/main/scala/flow/FlowResult.scala
@@ -134,8 +134,6 @@ case object FlowFailure {
   def from[T, U, Ctx](obj: FlowResult[T, Ctx]): FlowResult[U, Ctx] = obj match {
     case FlowSuccess(v, ctx, md) => FlowResult(obj, Failure[U](new Exception("Coerced to Failure")), ctx, md)
     case FlowFailure(e, ctx, md) => obj.asInstanceOf[FlowResult[U, Ctx]]
-    //    case FlowResult(Success(_), ctx, md, _) => FlowResult(obj, Failure[U](new Exception("Coerced to Failure")), ctx, md)
-    //    case FlowResult(Failure(_), _, _, _)    => obj.asInstanceOf[FlowResult[U, Ctx]]
   }
 }
 

--- a/core/src/main/scala/flow/Generator.scala
+++ b/core/src/main/scala/flow/Generator.scala
@@ -23,7 +23,7 @@ object Generator {
   def apply[T](source: Source[T, akka.NotUsed]): Generator[T, Unit] =
     Generator.Mat(toUnit(source))
 
-  def apply[T](stream: Stream[T]): Generator[T, Unit] =
+  def apply[T](stream: LazyList[T]): Generator[T, Unit] =
     Generator.Mat(toUnit(Source(stream)))
 
   def empty[T] = Generator[T](Source.empty[T])

--- a/core/src/main/scala/flow/GeneratorImplicits.scala
+++ b/core/src/main/scala/flow/GeneratorImplicits.scala
@@ -29,7 +29,7 @@ object GeneratorImplicits {
     def generator: Generator[T, Unit] = Generator(source)
   }
 
-  private[flow] case class WrappedStream[+T](stream: Stream[T]) {
+  private[flow] case class WrappedStream[+T](stream: LazyList[T]) {
     def generator: Generator[T, Unit] = Generator(stream)
   }
 
@@ -48,6 +48,6 @@ object GeneratorImplicits {
   implicit def sourceToWrapped[T](source: Source[T, akka.NotUsed]) =
     WrappedSource(source)
 
-  implicit def sourceToWrapped[T](stream: Stream[T]) =
+  implicit def sourceToWrapped[T](stream: LazyList[T]) =
     WrappedStream(stream)
 }


### PR DESCRIPTION
The main purpose of this commit is to upgrade the datto-flow package to scala 2.13.8

Note that the change is not going to be backwards compatible with previous versions of scala 2.12.x

The move from 2.12.x to 2.13.8 requires additional update outside of the version bump, notably:
- Conversion of `Stream` to `LazyList`
- A stricter exhaustiveness check, which required `FlowSuccess` and `FlowFailure` to be converted into actual classes that extend a `sealed trait FlowResult` in order to prevent downstream code from needing to add an extra catch-all when pattern matching on FlowResult if it was only checking against `FlowSuccess` and `FlowFailure`
- Because of conversion of `FlowResult` from a `case class` to a `sealed trait` there will be a loss of certain "for free" functions such as `copy` that will need to be handled differently.